### PR TITLE
chore:CS-679 disable container image push on pull request

### DIFF
--- a/.github/workflows/application-ci.yaml
+++ b/.github/workflows/application-ci.yaml
@@ -77,6 +77,7 @@ jobs:
     with:
       docker-file-path: docker/Dockerfile-policy-hub-service
       github-actor: ${{ github.actor }}
+      github-event: ${{ github.event_name }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -97,6 +98,7 @@ jobs:
     with:
       docker-file-path: docker/Dockerfile-policy-hub-migrations
       github-actor: ${{ github.actor }}
+      github-event: ${{ github.event_name }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/application-ci.yaml
+++ b/.github/workflows/application-ci.yaml
@@ -71,7 +71,7 @@ jobs:
       security-events: write
       id-token: write
     # Add quality gates dependency
-    needs: application-quality-gates
+#    needs: application-quality-gates
     
     uses: ./.github/workflows/build-and-publish-image-acr.yaml
     with:

--- a/.github/workflows/application-ci.yaml
+++ b/.github/workflows/application-ci.yaml
@@ -71,7 +71,7 @@ jobs:
       security-events: write
       id-token: write
     # Add quality gates dependency
-#    needs: application-quality-gates
+    needs: application-quality-gates
     
     uses: ./.github/workflows/build-and-publish-image-acr.yaml
     with:

--- a/.github/workflows/build-and-publish-image-acr.yaml
+++ b/.github/workflows/build-and-publish-image-acr.yaml
@@ -9,6 +9,9 @@ on:
       github-actor:
         required: true
         type: string
+      github-event:
+        required: true
+        type: string
     secrets: 
       AZURE_CLIENT_ID:
           required: true

--- a/.github/workflows/build-and-publish-image-acr.yaml
+++ b/.github/workflows/build-and-publish-image-acr.yaml
@@ -60,7 +60,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -69,7 +69,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       - name: Run Trivy vulnerability scanner
@@ -87,7 +87,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do

--- a/.github/workflows/build-and-publish-image-acr.yaml
+++ b/.github/workflows/build-and-publish-image-acr.yaml
@@ -60,7 +60,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -69,7 +69,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       - name: Run Trivy vulnerability scanner
@@ -87,7 +87,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do

--- a/.github/workflows/build-and-publish-image-acr.yaml
+++ b/.github/workflows/build-and-publish-image-acr.yaml
@@ -31,6 +31,13 @@ jobs:
       IMAGE_TAG: github-${{ github.run_id }}-${{ github.run_number }}
 
     steps:
+      - name: Debug if condition
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        run: |
+          echo ${{ inputs.github-actor }}
+          echo ${{ inputs.github-event }}
+          echo ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-and-publish-image-acr.yaml
+++ b/.github/workflows/build-and-publish-image-acr.yaml
@@ -31,13 +31,6 @@ jobs:
       IMAGE_TAG: github-${{ github.run_id }}-${{ github.run_number }}
 
     steps:
-      - name: Debug if condition
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
-        run: |
-          echo ${{ inputs.github-actor }}
-          echo ${{ inputs.github-event }}
-          echo ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -70,7 +63,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -79,7 +72,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       - name: Run Trivy vulnerability scanner
@@ -97,7 +90,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do

--- a/.github/workflows/build-and-publish-migrations-image-acr.yaml
+++ b/.github/workflows/build-and-publish-migrations-image-acr.yaml
@@ -63,7 +63,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -72,7 +72,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       # Scan container image using Trivy
@@ -91,7 +91,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if: ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
+        if: ${{ (inputs.github-actor != 'dependabot[bot]') && (inputs.github-event != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do

--- a/.github/workflows/build-and-publish-migrations-image-acr.yaml
+++ b/.github/workflows/build-and-publish-migrations-image-acr.yaml
@@ -9,6 +9,9 @@ on:
       github-actor:
         required: true
         type: string
+      github-event:
+        required: true
+        type: string
     secrets: 
       AZURE_CLIENT_ID:
           required: true

--- a/.github/workflows/build-and-publish-migrations-image-acr.yaml
+++ b/.github/workflows/build-and-publish-migrations-image-acr.yaml
@@ -60,7 +60,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -69,7 +69,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       # Scan container image using Trivy
@@ -88,7 +88,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if: ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
+        if: ${{ (inputs.github-actor != 'dependabot[bot]') || (inputs.github-event != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do

--- a/.github/workflows/build-and-publish-migrations-image-acr.yaml
+++ b/.github/workflows/build-and-publish-migrations-image-acr.yaml
@@ -60,7 +60,7 @@ jobs:
 
        # Establish authentication with azure
       - name: Azure CLI auth
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -69,7 +69,7 @@ jobs:
 
       # Login into Azure Container Registry (ACR)
       - name: ACR Login
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if:  ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         run: az acr login --name  ${{ secrets. AZURE_CONTAINER_REGISTRY }}
       
       # Scan container image using Trivy
@@ -88,7 +88,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
     
       - name: Push Docker image to ACR
-        if: ${{ inputs.github-actor != 'dependabot[bot]' }}
+        if: ${{ (inputs.github-actor != 'dependabot[bot]') || (github.event_name != 'pull_request') }}
         run: |
           for tag in $(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n')
           do


### PR DESCRIPTION
## Description
Disable container image push on pull request

## Why
To avoid redundant images on container registry.
We are not deploying container images created using the pull requests. 
